### PR TITLE
Update ExploitSettings.xml

### DIFF
--- a/ExploitGuard/ExploitSettings.xml
+++ b/ExploitGuard/ExploitSettings.xml
@@ -276,7 +276,7 @@
     <ExtensionPoints DisableExtensionPoints="true" />
     <StrictHandle Enable="true" />
     <DynamicCode BlockDynamicCode="true" AllowThreadsToOptOut="false" Audit="false" />
-    <SignedBinaries MicrosoftSignedOnly="true" AllowStoreSignedBinaries="false" Audit="false" AuditStoreSigned="false" />
+    <SignedBinaries MicrosoftSignedOnly="false" AllowStoreSignedBinaries="false" Audit="false" AuditStoreSigned="false" />
   </AppConfig>
   <!-- Windows Update -->
   <AppConfig Executable="SetupHost.exe">


### PR DESCRIPTION
Code Integrity determined that a process (\Device\HarddiskVolume1\Program Files\OpenSSH\ssh-agent.exe) attempted to load \Device\HarddiskVolume1\Program Files\OpenSSH\libcrypto.dll that did not meet the Microsoft signing level requirements.

libcrypto.dll is signed with "Microsoft 3rd Party Application Component"